### PR TITLE
Change Gradle `run` workingdir to core project to make running out of IntelliJ possible

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -10,7 +10,7 @@ task run(dependsOn: classes, type: JavaExec) {
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
-    workingDir = project.assetsDir
+    workingDir = project(":core").projectDir
     ignoreExitValue = true
 }
 


### PR DESCRIPTION
This is just a quick change to make this project a little easier for beginners to get started with. As a prospective contributor, I want to just get it up and running as quickly as possible, which this should help with.

On the main branch it currently fails if you try to run directly out of IntelliJ as it fails on [this line]( https://github.com/nanodeath/king-under-the-mountain/blob/7ca6100509151c4b117dc5ba9a4ef941dd3c110c/core/src/main/java/technology/rocketjump/undermount/modding/ArtifactCompatibilityChecker.java#L40), because the working dir is core/assets/, but that line expects it to be core/.

I haven't run a full build on this, but I have tested with this version of IntelliJ:

```
IntelliJ IDEA 2024.1.2 (Community Edition)
Build #IC-241.17011.79, built on May 21, 2024
Runtime version: 17.0.11+1-b1207.24 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Linux 6.5.0-28-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 3908M
Cores: 16
Registry:
  ide.experimental.ui=true
  terminal.new.ui=true
Kotlin: 241.17011.79-IJ
Current Desktop: zorin:GNOME
```

and I've also verified that `./gradlew run` on the command line also works.