### PR TITLE
Configure Gradle to always use JDK 17 toolchain.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,3 @@
-if (JavaVersion.current() != JavaVersion.VERSION_17) {
-    throw new GradleException("This build must be run with java 17, is currently " + JavaVersion.current())
-} else {
-    System.out.println("Java version: " + JavaVersion.current())
-}
-
 buildscript {
     repositories {
         mavenCentral()
@@ -39,8 +33,11 @@ allprojects {
 
 project(":desktop") {
     apply plugin: "java-library"
-    sourceCompatibility = 17
-
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
 
     dependencies {
         implementation project(":core")
@@ -126,8 +123,11 @@ project(":desktop") {
 
 project(":core") {
     apply plugin: "java-library"
-    sourceCompatibility = 17
-
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
 
     dependencies {
         api "com.badlogicgames.gdx:gdx:$gdxVersion"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "java"
 
-sourceCompatibility = 11
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "java"
 
-sourceCompatibility = 11
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 project.ext.mainClassName = "technology.rocketjump.undermount.launcher.DesktopLauncher"
@@ -12,6 +11,10 @@ task run(dependsOn: classes, type: JavaExec) {
     standardInput = System.in
     workingDir = project.assetsDir
     ignoreExitValue = true
+
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 task dist(type: Jar) {


### PR DESCRIPTION
This is another ergonomics change to make it easier for new users to get started without having a specific version of the JDK installed -- so long as they have a version that can run Gradle, the necessary JVM will automatically download.

This change enables you to use Java 11 or 21 or whatever globally, while the game compiles and runs (during development anyway) with the given distribution. I think later versions of Gradle 7 have improvements for JVM toolchains, but it works fine for me. I also removed the `sourceCompatibility` parameter because the build fails otherwise.

Toolchains are documented here: https://docs.gradle.org/7.6.2/userguide/toolchains.html

Builds still work from IntelliJ or from the terminal. There's no impact on build performance that I can see. Originally I specified the AdoptOpenJdk vendor per your readme, but at least in Gradle 7.2, this causes Gradle to unpack the downloaded distribution every build, which adds 4 seconds of needless wait time, so I left that out.