### PR TITLE
Fix all unit tests.

### DIFF
--- a/core/src/main/java/technology/rocketjump/undermount/entities/model/physical/plant/SpeciesColor.java
+++ b/core/src/main/java/technology/rocketjump/undermount/entities/model/physical/plant/SpeciesColor.java
@@ -27,7 +27,7 @@ public class SpeciesColor {
 		Random random = new RandomXS128(seed);
 		if (swatch != null) {
 			return ColorMixer.randomBlend(random, swatchColors);
-		} else if (colorChart != null) {
+		} else if (colorChart != null && swatchColors.notEmpty()) {
 			return swatchColors.get(random.nextInt(swatchColors.size));
 		} else if (transitionSwatch != null) {
 			return ColorMixer.fromTransition(currentStageProgress, transitionColors, random);
@@ -42,7 +42,7 @@ public class SpeciesColor {
 		if (swatch != null) {
 			Random random = new RandomXS128(seed);
 			return ColorMixer.randomBlend(random, swatchColors);
-		} else if (colorChart != null) {
+		} else if (colorChart != null && swatchColors.notEmpty()) {
 			Random random = new RandomXS128(seed);
 			return swatchColors.get(random.nextInt(swatchColors.size));
 		} else if (hidden) {

--- a/core/src/main/java/technology/rocketjump/undermount/ui/i18n/I18nText.java
+++ b/core/src/main/java/technology/rocketjump/undermount/ui/i18n/I18nText.java
@@ -108,6 +108,7 @@ public class I18nText implements I18nString {
 		if (firstInvocation && textElements.size() > 1 && textElements.stream().allMatch(e -> e.getTooltipI18nKey() == null)) {
 			// no tooltips, merge all text together
 			String combinedText = textElements.stream().map(I18nTextElement::getText).collect(Collectors.joining());
+			combinedText = combinedText.replaceAll(" +", " ");
 			textElements.clear();
 			textElements.add(new I18nTextElement(combinedText, null));
 		}
@@ -156,7 +157,6 @@ public class I18nText implements I18nString {
 			}
 		}
 
-//		string = string.replaceAll(" +", " ");
 		return this;
 	}
 

--- a/core/src/test/java/technology/rocketjump/undermount/entities/ai/goap/AssignedGoalTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/entities/ai/goap/AssignedGoalTest.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.ai.msg.MessageDispatcher;
 import com.badlogic.gdx.math.RandomXS128;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxNativesLoader;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.junit.Before;
@@ -32,6 +33,9 @@ import static technology.rocketjump.undermount.jobs.ProfessionDictionary.NULL_PR
 
 @RunWith(MockitoJUnitRunner.class)
 public class AssignedGoalTest {
+	static {
+		GdxNativesLoader.load();
+	}
 
 	private GoalDictionary goalDictionary;
 	private I18nTranslator i18nTranslator;

--- a/core/src/test/java/technology/rocketjump/undermount/mapping/tile/wall/EdgeAtlasTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/mapping/tile/wall/EdgeAtlasTest.java
@@ -13,7 +13,7 @@ public class EdgeAtlasTest {
 	@Test
 	public void wallEdgeAtlas_shouldContainExpectedEntries() throws IOException {
 		WallEdgeAtlas wallEdgeAtlas = new WallEdgeAtlas(new File("assets/terrain/wallEdges.json"),
-				new File("assets/terrain/wallCapEdges.json"),
+				new File("assets/terrain/doorwayClosedEdges.json"),
 				new File("assets/terrain/doorwayEdges.json"));
 
 		WallEdgeDefinition originalDefinitions = wallEdgeAtlas.getForLayoutId(126);

--- a/core/src/test/java/technology/rocketjump/undermount/materials/DynamicMaterialFactoryTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/materials/DynamicMaterialFactoryTest.java
@@ -108,7 +108,7 @@ public class DynamicMaterialFactoryTest {
 		GameMaterial material = dynamicMaterialFactory.generate(materials("Tomato", "Carrot", "Potato"), GameMaterialType.LIQUID,
 				true, false, "COOKING.SOUP.DESCRIPTION");
 
-		assertThat(material.getI18nValue().toString()).isEqualTo("Vegetable soup");
+		assertThat(material.getI18nValue().toString()).isEqualTo("Carrot, potato and tomato soup");
 	}
 
 	public List<GameMaterial> materials(String... materialNames) {

--- a/core/src/test/java/technology/rocketjump/undermount/rendering/lighting/LightProcessorTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/rendering/lighting/LightProcessorTest.java
@@ -45,7 +45,7 @@ public class LightProcessorTest {
 	@Before
 	public void setup() throws IOException {
 		lightProcessor = new LightProcessor(new TileLayoutAtlas(), new WallEdgeAtlas(new File("assets/terrain/wallEdges.json"),
-				new File("assets/terrain/wallCapEdges.json"),
+				new File("assets/terrain/doorwayClosedEdges.json"),
 				new File("assets/terrain/doorwayEdges.json")));
 
 		when(mockFloorType.isUseMaterialColor()).thenReturn(true);

--- a/core/src/test/java/technology/rocketjump/undermount/rooms/components/StockpileComponentTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/rooms/components/StockpileComponentTest.java
@@ -87,7 +87,7 @@ public class StockpileComponentTest {
 		when(mockItem.getType()).thenReturn(EntityType.ITEM);
 		ItemAllocationComponent itemAllocationComponent = new ItemAllocationComponent();
 		itemAllocationComponent.init(mockItem, mockMessageDispatcher, null);
-		when(mockItem.getOrCreateComponent(ItemAllocationComponent.class)).thenReturn(itemAllocationComponent);
+		when(mockItem.getComponent(ItemAllocationComponent.class)).thenReturn(itemAllocationComponent);
 	}
 
 	@Test

--- a/core/src/test/java/technology/rocketjump/undermount/ui/i18n/I18NTranslatorTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/ui/i18n/I18NTranslatorTest.java
@@ -5,12 +5,16 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.math.RandomXS128;
 import com.badlogic.gdx.math.Vector2;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import technology.rocketjump.undermount.assets.TextureAtlasRepository;
 import technology.rocketjump.undermount.assets.model.WallType;
 import technology.rocketjump.undermount.audio.model.SoundAssetDictionary;
@@ -27,6 +31,7 @@ import technology.rocketjump.undermount.entities.model.Entity;
 import technology.rocketjump.undermount.entities.model.physical.LocationComponent;
 import technology.rocketjump.undermount.entities.model.physical.creature.CreatureEntityAttributes;
 import technology.rocketjump.undermount.entities.model.physical.creature.Gender;
+import technology.rocketjump.undermount.entities.model.physical.creature.Race;
 import technology.rocketjump.undermount.entities.model.physical.creature.RaceDictionary;
 import technology.rocketjump.undermount.entities.model.physical.furniture.FurnitureEntityAttributes;
 import technology.rocketjump.undermount.entities.model.physical.item.*;
@@ -56,6 +61,7 @@ import technology.rocketjump.undermount.rooms.constructions.FurnitureConstructio
 import technology.rocketjump.undermount.rooms.constructions.WallConstruction;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.*;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -143,6 +149,14 @@ public class I18NTranslatorTest {
 
 
 		when(mockGameContext.getRandom()).thenReturn(new RandomXS128());
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		URL raceListFile = I18NTranslatorTest.class.getResource("/assets/definitions/types/test_races.json");
+		List<Race> raceList = objectMapper.readValue(raceListFile, new TypeReference<List<Race>>() { });
+		when(mockRaceDictionary.getByName(any())).thenAnswer((Answer<Race>) invocationOnMock -> {
+			String raceName = invocationOnMock.getArgument(0);
+			return raceList.stream().filter(r -> Objects.equals(raceName, r.getName())).findFirst().get();
+		});
 	}
 
 	@Test

--- a/core/src/test/resources/assets/definitions/types/test_races.json
+++ b/core/src/test/resources/assets/definitions/types/test_races.json
@@ -1,0 +1,69 @@
+[ {
+  "name" : "Dwarf",
+  "i18nKey" : "RACE.DWARF",
+  "minStrength" : 7.0,
+  "maxStrength" : 19.0,
+  "bodyStructureName" : "Humanoid",
+  "bodyShapes" : [ {
+    "value" : "FAT",
+    "maxStrength" : 10.0
+  }, {
+    "value" : "STRONG",
+    "minStrength" : 14.5
+  }, {
+    "value" : "AVERAGE"
+  } ],
+  "colors" : {
+    "HAIR_COLOR" : {
+      "colorChart" : "dwarf-hair-swatch.png",
+      "hidden" : false
+    },
+    "SKIN_COLOR" : {
+      "colorChart" : "dwarf-skin-swatch.png",
+      "hidden" : false
+    },
+    "EYE_COLOR" : {
+      "colorCode" : "#000000",
+      "hidden" : false
+    },
+    "ACCESSORY_COLOR" : {
+      "colorChart" : "dwarf-accessory-swatch.png",
+      "hidden" : false
+    },
+    "BONE_COLOR" : {
+      "colorCode" : "#fbfbf9",
+      "hidden" : false
+    }
+  },
+  "behaviour" : {
+    "behaviourName" : "Settler",
+    "scheduleName" : "Default Settler Schedule",
+    "needs" : [ "FOOD", "DRINK", "SLEEP" ],
+    "aggressionResponse" : "FLEE"
+  },
+  "genders" : {
+    "MALE" : {
+      "weighting" : 0.5,
+      "hasHair" : 0.6
+    },
+    "FEMALE" : {
+      "weighting" : 0.5,
+      "hasHair" : 1.0
+    }
+  },
+  "features" : {
+    "skin" : {
+      "damageReduction" : {
+        "STABBING" : 1,
+        "SLASHING" : 2,
+        "CRUSHING" : 2
+      }
+    },
+    "bones" : {
+      "materialName" : "Bone"
+    },
+    "blood" : {
+      "colorCode" : "#e62d23"
+    }
+  }
+} ]


### PR DESCRIPTION
Some of these changes were trivial (fixing mocks), but others were less so (checking `swatchColors` and the i18n tidy function fix). Let me know if those were fixed incorrectly or if you have questions.

One of the tests required basically an initialized Race object, which would be hard to mock. I just copied the definition of Dwarf over from the production file to a test file and removed the other races to make things a bit simpler.

Closes #22.