### PR TITLE
Pause music when application is in the background.

### DIFF
--- a/core/src/main/java/technology/rocketjump/undermount/UndermountApplicationAdapter.java
+++ b/core/src/main/java/technology/rocketjump/undermount/UndermountApplicationAdapter.java
@@ -2,6 +2,7 @@ package technology.rocketjump.undermount;
 
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.LifecycleListener;
 import com.badlogic.gdx.ai.msg.MessageDispatcher;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -53,7 +54,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-public class UndermountApplicationAdapter extends ApplicationAdapter {
+public class UndermountApplicationAdapter extends ApplicationAdapter implements LifecycleListener {
 
 	private GameRenderer gameRenderer;
 	private PrimaryCameraWrapper primaryCameraWrapper;
@@ -169,7 +170,18 @@ public class UndermountApplicationAdapter extends ApplicationAdapter {
 		}
 	}
 
+	@Override
+	public void pause() {
+		audioUpdater.pause();
+	}
+
+	@Override
+	public void resume() {
+		audioUpdater.resume();
+	}
+
 	public void onExit() {
+		// TODO perhaps this can be moved to the dispose() override?
 		messageDispatcher.dispatchMessage(MessageType.PERFORM_SAVE, new GameSaveMessage(false));
 		messageDispatcher.dispatchMessage(MessageType.SHUTDOWN_IN_PROGRESS);
 		Gdx.app.exit();

--- a/core/src/main/java/technology/rocketjump/undermount/audio/AudioUpdater.java
+++ b/core/src/main/java/technology/rocketjump/undermount/audio/AudioUpdater.java
@@ -27,4 +27,11 @@ public class AudioUpdater {
 		}
 	}
 
+	public void pause() {
+		musicJukebox.pauseMusic();
+	}
+
+	public void resume() {
+		musicJukebox.resumeMusic();
+	}
 }

--- a/core/src/main/java/technology/rocketjump/undermount/audio/MusicJukebox.java
+++ b/core/src/main/java/technology/rocketjump/undermount/audio/MusicJukebox.java
@@ -27,6 +27,8 @@ public class MusicJukebox implements Telegraph, AssetDisposable {
 	private List<FileHandle> musicFileList = new ArrayList<>();
 	private Music currentTrack;
 	private boolean shutdown;
+	/** The entire application has been sent to the background; not speed=0. */
+	private boolean paused;
 
 	@Inject
 	public MusicJukebox(MessageDispatcher messageDispatcher, UserPreferences userPreferences) {
@@ -93,7 +95,7 @@ public class MusicJukebox implements Telegraph, AssetDisposable {
 
 	// Note: Not using Updatable interface as this should run on all screens
 	public void update() {
-		if (shutdown || stopped) {
+		if (shutdown || stopped || paused) {
 			return;
 		}
 
@@ -122,5 +124,21 @@ public class MusicJukebox implements Telegraph, AssetDisposable {
 			currentTrack = null;
 		}
 		this.shutdown = true;
+	}
+
+	public void pauseMusic() {
+		if (currentTrack != null) {
+			// Safe to call even it not playing; will do nothing
+			currentTrack.pause();
+		}
+		paused = true;
+	}
+
+	public void resumeMusic() {
+		if (currentTrack != null) {
+			// Safe to call even if already playing; will do nothing
+			currentTrack.play();
+		}
+		paused = false;
 	}
 }

--- a/core/src/test/java/technology/rocketjump/undermount/audio/AudioUpdaterTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/audio/AudioUpdaterTest.java
@@ -1,0 +1,42 @@
+package technology.rocketjump.undermount.audio;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AudioUpdaterTest {
+	@Mock
+	private MusicJukebox musicJukebox;
+
+	@Mock
+	private SoundEffectManager soundEffectManager;
+
+	@Mock
+	private AudioMessageHandler audioMessageHandler;
+
+	private AudioUpdater audioUpdater;
+
+	@Before
+	public void setUp() throws Exception {
+		audioUpdater = new AudioUpdater(musicJukebox, soundEffectManager, audioMessageHandler);
+	}
+
+	@Test
+	public void pause_pausesMusicJukebox() {
+		audioUpdater.pause();
+
+		verify(musicJukebox, only()).pauseMusic();
+	}
+
+	@Test
+	public void resume_resumesMusicJukebox() {
+		audioUpdater.resume();
+
+		verify(musicJukebox, only()).resumeMusic();
+	}
+}

--- a/core/src/test/java/technology/rocketjump/undermount/audio/MusicJukeboxTest.java
+++ b/core/src/test/java/technology/rocketjump/undermount/audio/MusicJukeboxTest.java
@@ -1,0 +1,73 @@
+package technology.rocketjump.undermount.audio;
+
+import com.badlogic.gdx.Audio;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.ai.msg.MessageDispatcher;
+import com.badlogic.gdx.audio.Music;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import technology.rocketjump.undermount.persistence.UserPreferences;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MusicJukeboxTest {
+	@Mock
+	private MessageDispatcher messageDispatcher;
+
+	@Mock
+	private UserPreferences userPreferences;
+
+	@Mock
+	private Audio audio;
+
+	@Mock
+	private Music music;
+
+	private MusicJukebox musicJukebox;
+
+	@Before
+	public void setUp() throws Exception {
+		// Returns whatever the provided default value is
+		when(userPreferences.getPreference(any(), any())).then((Answer<String>) invocationOnMock -> invocationOnMock.getArgument(1));
+		when(audio.newMusic(any())).thenReturn(music);
+		Gdx.audio = audio;
+
+		musicJukebox = new MusicJukebox(messageDispatcher, userPreferences);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		musicJukebox.dispose();
+		Gdx.audio = null;
+	}
+
+	@Test
+	public void pauseMusic_PausesIfCurrentTrackAvailable() {
+		// Initialize and start the track we need to pause.
+		musicJukebox.update();
+
+		musicJukebox.pauseMusic();
+
+		verify(music).pause();
+	}
+
+	@Test
+	public void resumeMusic_PausesIfCurrentTrackAvailable() {
+		// Initialize and start the track we need to resume.
+		musicJukebox.update();
+
+		musicJukebox.resumeMusic();
+
+		// The update() method calls play too actually, so we verify play is called *twice*.
+		verify(music, times(2)).play();
+	}
+}

--- a/desktop/src/main/java/com/badlogic/gdx/backends/lwjgl/UndermountLwjglApplication.java
+++ b/desktop/src/main/java/com/badlogic/gdx/backends/lwjgl/UndermountLwjglApplication.java
@@ -82,6 +82,7 @@ public class UndermountLwjglApplication implements Application {
 				LwjglApplicationConfiguration.disableAudio = true;
 			}
 		}
+		addLifecycleListener(((UndermountApplicationAdapter)listener));
 		files = new LwjglFiles();
 		input = new LwjglInput();
 		net = new LwjglNet(config);


### PR DESCRIPTION
Modifying the main application adapter to add the LifecycleListener is a bigger change than I was expecting, but IMO is the most natural way to accomplish this, too.

MusicJukebox has an ever-increasing number of possible states, too, which is....interesting.

Hurray for tests, even if they are a little useless.

Closes #25.